### PR TITLE
Implement skip function in json_protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # browser-thrift
 
-Patched version of Apache Thrift Node.js library to work with Webpack / Browserify.
+Patched version of Apache Thrift Node.js library to work either with Webpack /
+Browserify or with nodejs.
 
 ### Usage
-It is necessary to replace all `require('thrift')` with `require('browser-thrift')` in the thrift generated files. You may use `sed` for that:
+
+It is necessary to replace all `require('thrift')` with
+`require('browser-thrift')` in the thrift generated files. You may use `sed`
+for that:
+
 ```sh
 for f in <gen_folder>/*; do
   sed -i '' -e \"s/'thrift'/'browser-thrift'/\" $f

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,1 @@
+module.exports = require("./src");

--- a/node.js
+++ b/node.js
@@ -1,0 +1,1 @@
+module.exports = require("thrift");

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -13,6 +18,29 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "thrift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
+      "integrity": "sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=",
+      "requires": {
+        "node-int64": "0.4.0",
+        "q": "1.5.1",
+        "ws": "5.1.1"
+      }
+    },
+    "ws": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+      "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
+      "requires": {
+        "async-limiter": "1.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -29,9 +24,9 @@
       "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
       "integrity": "sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=",
       "requires": {
-        "node-int64": "0.4.0",
-        "q": "1.5.1",
-        "ws": "5.1.1"
+        "node-int64": "^0.4.0",
+        "q": "^1.5.0",
+        "ws": ">= 2.2.3"
       }
     },
     "ws": {
@@ -39,7 +34,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
       "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
       "requires": {
-        "async-limiter": "1.0.0"
+        "async-limiter": "~1.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "browser-thrift",
   "version": "0.7.0",
-  "description": "Thrift binding for browser",
-  "main": "./src/index.js",
+  "description": "Thrift binding for browser and nodejs",
+  "main": "./node.js",
+  "browser": "./browser.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vh/browser-thrift.git"
@@ -10,9 +11,13 @@
   "keywords": [
     "thrift",
     "webpack",
-    "browserify"
+    "browserify",
+    "universal"
   ],
-  "author": "Vadim Homchik",
+  "authors": [
+    "Vadim Homchik",
+    "Paolo Scanferla <paolo.scanferla@mondora.com>"
+  ],
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/vh/browser-thrift/issues"
@@ -20,6 +25,7 @@
   "homepage": "https://github.com/vh/browser-thrift#readme",
   "dependencies": {
     "bluebird": "^3.5.1",
-    "node-int64": "^0.4.0"
+    "node-int64": "^0.4.0",
+    "thrift": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/vh/browser-thrift#readme",
   "dependencies": {
-    "bluebird": "^3.5.1",
     "node-int64": "^0.4.0",
     "thrift": "^0.11.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,6 @@ exports.Protocol = exports.TJSONProtocol = require('./json_protocol');
 exports.TBinaryProtocol = require('./binary_protocol');
 exports.TCompactProtocol = require('./compact_protocol');
 
-var Promise = require('bluebird');
 exports.Q = {
   defer: function() {
     var deferred = {};

--- a/src/json_protocol.js
+++ b/src/json_protocol.js
@@ -754,5 +754,65 @@ TJSONProtocol.prototype.getTransport = function() {
  * Method to arbitrarily skip over data
  */
 TJSONProtocol.prototype.skip = function(type) {
-  throw new Error('skip not supported yet');
+    switch (type) {
+    case Type.STOP:
+      return;
+    case Type.BOOL:
+      this.readBool();
+      break;
+    case Type.BYTE:
+      this.readByte();
+      break;
+    case Type.I16:
+      this.readI16();
+      break;
+    case Type.I32:
+      this.readI32();
+      break;
+    case Type.I64:
+      this.readI64();
+      break;
+    case Type.DOUBLE:
+      this.readDouble();
+      break;
+    case Type.STRING:
+      this.readString();
+      break;
+    case Type.STRUCT:
+      this.readStructBegin();
+      while (true) {
+        var r = this.readFieldBegin();
+        if (r.ftype === Type.STOP) {
+          break;
+        }
+        this.skip(r.ftype);
+        this.readFieldEnd();
+      }
+      this.readStructEnd();
+      break;
+    case Type.MAP:
+      var mapBegin = this.readMapBegin();
+      for (var i = 0; i < mapBegin.size; ++i) {
+        this.skip(mapBegin.ktype);
+        this.skip(mapBegin.vtype);
+      }
+      this.readMapEnd();
+      break;
+    case Type.SET:
+      var setBegin = this.readSetBegin();
+      for (var i2 = 0; i2 < setBegin.size; ++i2) {
+        this.skip(setBegin.etype);
+      }
+      this.readSetEnd();
+      break;
+    case Type.LIST:
+      var listBegin = this.readListBegin();
+      for (var i3 = 0; i3 < listBegin.size; ++i3) {
+        this.skip(listBegin.etype);
+      }
+      this.readListEnd();
+      break;
+    default:
+      throw new  Error("Invalid type: " + type);
+  }
 };


### PR DESCRIPTION
This is a port of apache/thrift@91c74b6.

Having the `skip` method implemented allows the server to add properties to interfaces without breaking the client.

From manual tests everything appears to be working.
